### PR TITLE
Allow both IPv4 and IPv6 records at the same time

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,8 +118,11 @@ func (cfg *Configuration) Check() error {
 		if rs.TTL < 1 {
 			return fmt.Errorf("invalid record set TTL %d for %s", rs.TTL, rs.Name)
 		}
-		cfg.Route53.HandleIPv4 = rs.Type == route53.RRTypeA
-		cfg.Route53.HandleIPv6 = rs.Type == route53.RRTypeAaaa
+		if rs.Type == route53.RRTypeA {
+			cfg.Route53.HandleIPv4 = true
+		} else if rs.Type == route53.RRTypeAaaa {
+			cfg.Route53.HandleIPv6 = true
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Change config check to not disable IPv4 if a following record uses IPv6 and vice versa.