### PR TITLE
Add builds for mips architectures

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,9 +23,16 @@ builds:
       - amd64
       - arm
       - arm64
+      - mips
+      - mipsle
+      - mips64
+      - mips64le
     goarm:
       - 6
       - 7
+    gomips:
+      - softfloat
+      - hardfloat
     ignore:
       - goos: freebsd
         goarch: arm


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

Adds builds for the various mips architecture combinations (useful for running on networking gear like Unifi devices). I've been building these manually from time to time but I'd love to know if you'd consider releasing for mips!