### PR TITLE
Add ipify.org as an IP Provider

### DIFF
--- a/docs/config/index.md
+++ b/docs/config/index.md
@@ -40,6 +40,8 @@ You can override this using the [`--config` flag or `CONFIG` env var](../usage/c
         - name: "another.example2.com."
           type: "A"
           ttl: 600
+    
+    ipProvider: "identme"
     ```
 
 ## Environment variables
@@ -64,6 +66,8 @@ All configuration from file can be transposed into environment variables. As an 
         - name: "another.example2.com."
           type: "A"
           ttl: 600
+
+    ipProvider: "identme"
     ```
 
 Can be transposed to:
@@ -83,7 +87,16 @@ Can be transposed to:
     DDNSR53_ROUTE53_RECORDSSET_2_NAME=another.example2.com.
     DDNSR53_ROUTE53_RECORDSSET_2_TYPE=A
     DDNSR53_ROUTE53_RECORDSSET_2_TTL=600
+
+    DDNSR53_IPPROVIDER=identme
     ```
+
+# IP Provider
+
+You can choose between two different service to retrieve your external IP:
+
+- [IdentMe](https://ident.me) - (use the value `identme`)
+- [Ipify](https://www.ipify.org/) - (use the value `ipify`)
 
 ## Reference
 

--- a/internal/app/ddnsr53.go
+++ b/internal/app/ddnsr53.go
@@ -12,7 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/crazy-max/ddns-route53/v2/internal/config"
 	"github.com/crazy-max/ddns-route53/v2/internal/model"
-	"github.com/crazy-max/ddns-route53/v2/pkg/identme"
+	"github.com/crazy-max/ddns-route53/v2/pkg/ip_provider"
 	"github.com/crazy-max/ddns-route53/v2/pkg/utl"
 	"github.com/hako/durafmt"
 	"github.com/robfig/cron/v3"
@@ -25,7 +25,7 @@ type DDNSRoute53 struct {
 	cfg      *config.Config
 	cron     *cron.Cron
 	r53      *route53.Route53
-	im       *identme.Client
+	im       ip_provider.Client
 	jobID    cron.EntryID
 	lastIPv4 net.IP
 	lastIPv6 net.IP
@@ -69,12 +69,13 @@ func New(meta model.Meta, cfg *config.Config) (*DDNSRoute53, error) {
 
 	return &DDNSRoute53{
 		meta: meta,
-		cfg: cfg,
+		cfg:  cfg,
 		cron: cron.New(cron.WithParser(cron.NewParser(
-			cron.SecondOptional|cron.Minute|cron.Hour|cron.Dom|cron.Month|cron.Dow|cron.Descriptor),
+			cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor),
 		)),
 		r53: route53.New(sess, &aws.Config{Credentials: creds}),
-		im: identme.NewClient(
+		im: ip_provider.NewClient(
+			cfg.Ipprovider,
 			meta.UserAgent,
 			cfg.Cli.MaxRetries,
 		),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Cli         Cli          `yaml:"-" json:"-" label:"-" file:"-"`
 	Credentials *Credentials `yaml:"credentials,omitempty" json:"credentials,omitempty" validate:"omitempty"`
 	Route53     *Route53     `yaml:"route53,omitempty" json:"route53,omitempty" validate:"required"`
+	Ipprovider  string       `yaml:"ipProvider,omitempty" json:"ipProvider,omitempty"`
 }
 
 // Load returns Configuration struct

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -65,6 +65,7 @@ func TestLoadFile(t *testing.T) {
 					HandleIPv4: utl.NewTrue(),
 					HandleIPv6: utl.NewTrue(),
 				},
+				Ipprovider: "identme",
 			},
 		},
 	}
@@ -109,6 +110,7 @@ func TestLoadEnv(t *testing.T) {
 				"DDNSR53_ROUTE53_RECORDSSET_0_NAME=ddns.example.com.",
 				"DDNSR53_ROUTE53_RECORDSSET_0_TYPE=A",
 				"DDNSR53_ROUTE53_RECORDSSET_0_TTL=300",
+				"DDNSR53_IPPROVIDER=ipify",
 			},
 			expected: &Config{
 				Credentials: &Credentials{
@@ -127,6 +129,7 @@ func TestLoadEnv(t *testing.T) {
 					HandleIPv4: utl.NewTrue(),
 					HandleIPv6: utl.NewFalse(),
 				},
+				Ipprovider: "ipify",
 			},
 			wantErr: false,
 		},

--- a/internal/config/fixtures/config.test.yml
+++ b/internal/config/fixtures/config.test.yml
@@ -14,3 +14,5 @@ route53:
     - name: "another.example2.com."
       type: "A"
       ttl: 600
+
+ipProvider: "identme"

--- a/pkg/ip_provider/commons/main.go
+++ b/pkg/ip_provider/commons/main.go
@@ -1,0 +1,8 @@
+package commons
+
+import "net"
+
+type Client interface {
+	IPv4() (net.IP, error)
+	IPv6() (net.IP, error)
+}

--- a/pkg/ip_provider/main.go
+++ b/pkg/ip_provider/main.go
@@ -1,0 +1,18 @@
+package ip_provider
+
+import (
+	"github.com/crazy-max/ddns-route53/v2/pkg/ip_provider/commons"
+	"github.com/crazy-max/ddns-route53/v2/pkg/ip_provider/providers/identme"
+	"github.com/crazy-max/ddns-route53/v2/pkg/ip_provider/providers/ipify"
+)
+
+type Client = commons.Client
+
+// NewClient initializes a new ipify client
+func NewClient(provider string, userAgent string, maxRetries int) (c Client) {
+	if provider == "ipify" {
+		return ipify.NewClient(userAgent, maxRetries)
+	}
+
+	return identme.NewClient(userAgent, maxRetries)
+}

--- a/pkg/ip_provider/providers/identme/client.go
+++ b/pkg/ip_provider/providers/identme/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/crazy-max/ddns-route53/v2/pkg/ip_provider/commons"
 	"github.com/jpillora/backoff"
 	"github.com/pkg/errors"
 )
@@ -19,7 +20,7 @@ type Client struct {
 }
 
 // NewClient initializes a new identme client
-func NewClient(userAgent string, maxRetries int) (c *Client) {
+func NewClient(userAgent string, maxRetries int) (c commons.Client) {
 	return &Client{
 		UserAgent:  userAgent,
 		MaxRetries: maxRetries,

--- a/pkg/ip_provider/providers/identme/client_test.go
+++ b/pkg/ip_provider/providers/identme/client_test.go
@@ -7,12 +7,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/crazy-max/ddns-route53/v2/pkg/ip_provider/commons"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 var (
-	c *Client
+	c commons.Client
 )
 
 func TestMain(m *testing.M) {

--- a/pkg/ip_provider/providers/ipify/client.go
+++ b/pkg/ip_provider/providers/ipify/client.go
@@ -1,0 +1,90 @@
+package ipify
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/crazy-max/ddns-route53/v2/pkg/ip_provider/commons"
+	"github.com/jpillora/backoff"
+	"github.com/pkg/errors"
+)
+
+type Client struct {
+	UserAgent  string
+	MaxRetries int
+}
+
+// NewClient initializes a new ipify client
+func NewClient(userAgent string, maxRetries int) (c commons.Client) {
+	return &Client{
+		UserAgent:  userAgent,
+		MaxRetries: maxRetries,
+	}
+}
+
+// IPv4 returns your IPv4 address from ipify.org service
+func (c *Client) IPv4() (net.IP, error) {
+	ip, err := c.wanIP("https://api.ipify.org/")
+	if err != nil {
+		return nil, err
+	}
+	if ip == nil || !strings.Contains(ip.String(), ".") {
+		return nil, fmt.Errorf("invalid IPv4 address: %s", ip.String())
+	}
+	return ip, nil
+}
+
+// IPv6 returns your IPv6 address from ipify.org service
+func (c *Client) IPv6() (net.IP, error) {
+	ip, err := c.wanIP("https://api64.ipify.org/")
+	if err != nil {
+		return nil, err
+	}
+	if ip == nil || !strings.Contains(ip.String(), ":") {
+		return nil, fmt.Errorf("invalid IPv6 address: %s", ip.String())
+	}
+	return ip, nil
+}
+
+func (c *Client) wanIP(apiURL string) (net.IP, error) {
+	var err error
+	var req *http.Request
+	var res *http.Response
+
+	client := &http.Client{}
+	b := &backoff.Backoff{
+		Jitter: true,
+	}
+
+	req, err = http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "request failed")
+	}
+
+	req.Header.Add("User-Agent", c.UserAgent)
+	for tries := 0; tries < c.MaxRetries; tries++ {
+		res, err = client.Do(req)
+		if err != nil {
+			time.Sleep(b.Duration())
+			continue
+		}
+		defer res.Body.Close()
+
+		ip, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return nil, errors.Wrap(err, "request failed")
+		}
+
+		if res.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("received invalid status code %d from ipify.org: %s", res.StatusCode, res.Body)
+		}
+
+		return net.ParseIP(string(ip)), nil
+	}
+
+	return nil, errors.Wrap(err, "request failed")
+}

--- a/pkg/ip_provider/providers/ipify/client_test.go
+++ b/pkg/ip_provider/providers/ipify/client_test.go
@@ -1,0 +1,50 @@
+package ipify
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/crazy-max/ddns-route53/v2/pkg/ip_provider/commons"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	c commons.Client
+)
+
+func TestMain(m *testing.M) {
+	c = NewClient(
+		fmt.Sprintf("ddns-route53/test go/%s %s", runtime.Version()[2:], strings.Title(runtime.GOOS)),
+		3,
+	)
+	os.Exit(m.Run())
+}
+
+func TestClient_IPv4(t *testing.T) {
+	ip, err := c.IPv4()
+	if err != nil && isNetworkUnavailable(err) {
+		t.Skip("Skipping unsupported IPv4 on host")
+	}
+	require.NoError(t, err)
+	assert.NotEmpty(t, ip)
+	fmt.Println("IPv4:", ip)
+}
+
+func TestClient_IPv6(t *testing.T) {
+	ip, err := c.IPv6()
+	if err != nil && isNetworkUnavailable(err) {
+		t.Skip("Skipping unsupported IPv6 on host")
+	}
+	require.NoError(t, err)
+	assert.NotEmpty(t, ip)
+	fmt.Println("IPv6:", ip)
+}
+
+func isNetworkUnavailable(err error) bool {
+	return strings.Contains(err.Error(), "no such host") ||
+		strings.Contains(err.Error(), "network is unreachable")
+}


### PR DESCRIPTION
Just added a different service to retrieve the IP address, ident.me is blocked by pi-hole, by default, and if I whitelist it the HTTPS certificate is not verified. So, I've added an `ip_provider` package that based on the given `provider` returns a client like the one created from the previous `identme` package.

It's the first I write something in Go, so if there is something bad let me know :)

P.S. From my connection I cannot test the IPv6 feature, so form me the tests of this method are broken