### PR TITLE
Added quotations to linux service.

### DIFF
--- a/docs/install/linux-service.md
+++ b/docs/install/linux-service.md
@@ -24,7 +24,7 @@ Restart=always
 #Environment=TZ=Europe/Paris
 #Environment=AWS_ACCESS_KEY_ID=********
 #Environment=AWS_SECRET_ACCESS_KEY=********
-Environment=SCHEDULE=*/30 * * * *
+Environment=SCHEDULE="*/30 * * * *"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
I was having issues with this specific bug: `Cannot start ddns-route53 error="expected 5 to 6 fields, found 1: [*/30]"`; adding these quotations fixed this bug for me.
