### PR TITLE
Allow Non-Static AWS Credentials

### DIFF
--- a/docs/config/credentials.md
+++ b/docs/config/credentials.md
@@ -2,6 +2,12 @@
 
 AWS credentials are required for getting access and manage your Route53 zone.
 
+!!! note
+    When running ddns-route53 on an EC2 instance or in a Kubernetes cluster configured
+    with IAM roles for service accounts (IRSA) AWS credentials are not required.
+    ddns-route53 will automatically detect the presence of the configured IAM role
+    and use it to authenticate with Route 53.
+
 ```yaml
 credentials:
   accessKeyID: "ABCDEFGHIJKLMNO123456"

--- a/docs/usage/prerequisites.md
+++ b/docs/usage/prerequisites.md
@@ -4,6 +4,13 @@ I assume you have already created a [Route 53 Hosted Zones](https://console.aws.
 as a **Public Hosted Zone** type and setted Amazon name servers in your domain
 name registrar.
 
+!!! note
+    If you are using [EC2 IAM instance roles](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
+    or [AWS IAM roles for service accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html),
+    creating a user is not required. Configuration of IAM roles is beyond the scope of this
+    document, and is discussed in the official AWS documentation linked above.
+    For all other use cases, follow the steps below to create a policy and user.
+
 Go to the [IAM Policies page](https://console.aws.amazon.com/iam/home#/policies)
 and click on **Create Policy**.
 

--- a/pkg/route53/route53.go
+++ b/pkg/route53/route53.go
@@ -27,7 +27,6 @@ func New(ctx context.Context, accessKey, secretKey, hostedZoneID string, maxRetr
 		// currently only has a single regional endpoint in us-east-1
 		// http://docs.aws.amazon.com/general/latest/gr/rande.html#r53_region
 		config.WithRegion("us-east-1"),
-		config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")),
 		config.WithRetryer(func() aws.Retryer {
 			r := retry.AddWithMaxAttempts(retry.NewStandard(), maxRetries)
 			r = retry.AddWithMaxBackoffDelay(r, maxBackoffDelay)
@@ -36,6 +35,9 @@ func New(ctx context.Context, accessKey, secretKey, hostedZoneID string, maxRetr
 	)
 	if err != nil {
 		return nil, err
+	}
+	if len(accessKey) > 0 && len(secretKey) > 0 {
+		cfg.Credentials = credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")
 	}
 	return &Client{
 		ctx:          ctx,


### PR DESCRIPTION
The current AWS credentials configuration requires a static IAM access key and secret. However, the AWS SDK can automatically handle providing credentials from IAM instance roles, as well as through service account tokens using IRSA in Kubernetes.

To allow these auth methods, skip setting the static credentials provider unless static credentials are provided. This allows the other authentication methods to be handled transparently if available.

The downside of this change is that it provides a less clear error message if all authentication methods are entirely missing, however the ability to use other credential chains is probably worth it.

I've tested this by simulating the container running as a Kubernetes pod using IRSA with the following configuration:
```
docker run -v ./token:/var/run/sa-token:ro -e AWS_DEFAULT_REGION=us-west-2 -e AWS_REGION=us-west-2 -e AWS_ROLE_ARN=arn:aws:iam::REDACTED:role/REDACTED -e AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/sa-token -e AWS_STS_REGIONAL_ENDPOINTS=regional -e 'DDNSR53_ROUTE53_HOSTEDZONEID=REDACTED' -e 'DDNSR53_ROUTE53_RECORDSSET_0_NAME=REDACTED' -e 'DDNSR53_ROUTE53_RECORDSSET_0_TYPE=A' -e 'DDNSR53_ROUTE53_RECORDSSET_0_TTL=300' -e SCHEDULE='*/30 * * * *' -it ddns-route53:holly
Mon, 06 May 2024 05:49:47 UTC INF Starting ddns-route53 version=v2.12.0-3-g6a69d4c.m
Mon, 06 May 2024 05:49:47 UTC INF Configuration loaded from 4 environment variables
Mon, 06 May 2024 05:49:48 UTC INF Current WAN IPv4: REDACTED
Mon, 06 May 2024 05:49:50 UTC INF 1 record(s) set updated changes={"ChangeInfo":{"Comment":"Updated by ddns-route53 v2.12.0-3-g6a69d4c.m at 2024-05-06 05:49:50","Id":"/change/C10150071THCU7QRC3B8B","Status":"PENDING","SubmittedAt":"2024-05-06T05:49:47.441Z"},"ResultMetadata":{}}
Mon, 06 May 2024 05:49:50 UTC INF Cron initialized with schedule */30 * * * *
Mon, 06 May 2024 05:49:50 UTC INF Next run in 10 minutes (2024-05-06 06:00:00 +0000 UTC)
^CMon, 06 May 2024 05:49:55 UTC WRN Caught signal interrupt
```

And using static credentials
```
docker run -e 'DDNSR53_CREDENTIALS_ACCESSKEYID=REDACTED' -e 'DDNSR53_CREDENTIALS_SECRETACCESSKEY=REDACTED' -e 'DDNSR53_ROUTE53_HOSTEDZONEID=REDACTED' -e 'DDNSR53_ROUTE53_RECORDSSET_0_NAME=REDACTED' -e 'DDNSR53_ROUTE53_RECORDSSET_0_TYPE=A' -e 'DDNSR53_ROUTE53_RECORDSSET_0_TTL=300' -e SCHEDULE='*/30 * * * *' -it ddns-route53:holly
Mon, 06 May 2024 05:55:18 UTC INF Starting ddns-route53 version=v2.12.0-3-g6a69d4c.m
Mon, 06 May 2024 05:55:18 UTC INF Configuration loaded from 6 environment variables
Mon, 06 May 2024 05:55:19 UTC INF Current WAN IPv4: REDACTED
Mon, 06 May 2024 05:55:20 UTC INF 1 record(s) set updated changes={"ChangeInfo":{"Comment":"Updated by ddns-route53 v2.12.0-3-g6a69d4c.m at 2024-05-06 05:55:19","Id":"/change/C0031075VEO58EQZIRRJ","Status":"PENDING","SubmittedAt":"2024-05-06T05:55:17.133Z"},"ResultMetadata":{}}
Mon, 06 May 2024 05:55:20 UTC INF Cron initialized with schedule */30 * * * *
Mon, 06 May 2024 05:55:20 UTC INF Next run in 4 minutes (2024-05-06 06:00:00 +0000 UTC)
^CMon, 06 May 2024 05:55:23 UTC WRN Caught signal interrupt
```

Also, this is my first time writing go code, so if you have style feedback that is appreciated.