### PR TITLE
refactor WAN IP providers and client transport handling

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,13 +16,12 @@ ddns-route53 --schedule "CRON_TZ=Asia/Tokyo */30 * * * *"
 The public IP address is retrieved from one of several providers. The first one to return a valid IP address is used.
 
 ### IPv4
+* https://checkip.global.api.aws
+* https://checkip.amazonaws.com
+* https://cloudflare.com/cdn-cgi/trace
 * https://ipv4.nsupdate.info/myip
-* https://v4.ident.me
-* https://ipv4.yunohost.org
-* https://ipv4.wtfismyip.com/text
 
 ### IPv6
+* https://checkip.global.api.aws
+* https://cloudflare.com/cdn-cgi/trace
 * https://ipv6.nsupdate.info/myip
-* https://v6.ident.me
-* https://ipv6.yunohost.org
-* https://ipv6.wtfismyip.com/text

--- a/internal/app/ddnsr53.go
+++ b/internal/app/ddnsr53.go
@@ -15,6 +15,7 @@ import (
 	"github.com/crazy-max/ddns-route53/v2/pkg/utl"
 	"github.com/crazy-max/ddns-route53/v2/pkg/wanip"
 	"github.com/dromara/carbon/v2"
+	"github.com/pkg/errors"
 	"github.com/robfig/cron/v3"
 	"github.com/rs/zerolog/log"
 )
@@ -111,28 +112,38 @@ func (c *DDNSRoute53) Run() {
 	}
 
 	if *c.cfg.Route53.HandleIPv4 {
-		var wanErrs wanip.Errors
-		wanIPv4, wanErrs = c.wip.IPv4()
+		var wanErr error
+		wanIPv4, wanErr = c.wip.IPv4()
 		wanLogger := log.Error()
 		if wanIPv4 != nil {
 			wanLogger = log.Debug()
 			log.Info().Msgf("Current WAN IPv4: %s", wanIPv4)
 		}
-		for _, wanIPErr := range wanErrs {
-			wanLogger.Err(wanIPErr.Err).Str("provider-url", wanIPErr.ProviderURL).Msg("Cannot retrieve WAN IPv4 address")
+		var lookupErr *wanip.ProviderError
+		if errors.As(wanErr, &lookupErr) {
+			for _, failure := range lookupErr.Failures {
+				wanLogger.Err(failure.Err).Str("provider-url", failure.URL).Msg("Cannot retrieve WAN IPv4 address")
+			}
+		} else if wanErr != nil {
+			wanLogger.Err(wanErr).Msg("Cannot retrieve WAN IPv4 address")
 		}
 	}
 
 	if *c.cfg.Route53.HandleIPv6 {
-		var wanErrs wanip.Errors
-		wanIPv6, wanErrs = c.wip.IPv6()
+		var wanErr error
+		wanIPv6, wanErr = c.wip.IPv6()
 		wanLogger := log.Error()
 		if wanIPv6 != nil {
 			wanLogger = log.Debug()
 			log.Info().Msgf("Current WAN IPv6: %s", wanIPv6)
 		}
-		for _, wanIPErr := range wanErrs {
-			wanLogger.Err(wanIPErr.Err).Str("provider-url", wanIPErr.ProviderURL).Msg("Cannot retrieve WAN IPv6 address")
+		var lookupErr *wanip.ProviderError
+		if errors.As(wanErr, &lookupErr) {
+			for _, failure := range lookupErr.Failures {
+				wanLogger.Err(failure.Err).Str("provider-url", failure.URL).Msg("Cannot retrieve WAN IPv6 address")
+			}
+		} else if wanErr != nil {
+			wanLogger.Err(wanErr).Msg("Cannot retrieve WAN IPv6 address")
 		}
 	}
 

--- a/pkg/wanip/client.go
+++ b/pkg/wanip/client.go
@@ -72,9 +72,14 @@ func (c *Client) IPv6() (net.IP, error) {
 }
 
 func (c *Client) lookup(providers []provider, v6 bool) (net.IP, error) {
-	var failures []ProviderFailure
+	httpc, err := c.httpClient(v6)
+	if err != nil {
+		return nil, err
+	}
+
+	failures := make([]ProviderFailure, 0, len(providers))
 	for _, p := range providers {
-		ip, err := c.getIP(p, v6)
+		ip, err := c.getIP(httpc, p)
 		if err != nil {
 			failures = append(failures, ProviderFailure{
 				URL: p.URL,
@@ -93,14 +98,7 @@ func (c *Client) lookup(providers []provider, v6 bool) (net.IP, error) {
 	return nil, &ProviderError{Failures: failures}
 }
 
-func (c *Client) getIP(p provider, v6 bool) (net.IP, error) {
-	httpc := *c.hc
-	if t, err := c.transport(v6); err != nil {
-		return nil, err
-	} else {
-		httpc.Transport = t
-	}
-
+func (c *Client) getIP(httpc *http.Client, p provider) (net.IP, error) {
 	req, err := http.NewRequestWithContext(c.ctx, "GET", p.URL, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "request failed")
@@ -131,7 +129,16 @@ func (c *Client) getIP(p provider, v6 bool) (net.IP, error) {
 	return ip, nil
 }
 
-// transport returns transport that uses the specified interface.
+func (c *Client) httpClient(v6 bool) (*http.Client, error) {
+	httpc := *c.hc
+	if t, err := c.transport(v6); err != nil {
+		return nil, err
+	} else {
+		httpc.Transport = t
+	}
+	return &httpc, nil
+}
+
 func (c *Client) transport(v6 bool) (*http.Transport, error) {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
@@ -164,7 +171,6 @@ func (c *Client) transport(v6 bool) (*http.Transport, error) {
 	}, nil
 }
 
-// interfaceAddress returns the first IPv4/IPv6 address of the given interface.
 func interfaceAddress(interfaceName string, v6 bool) (net.IP, error) {
 	addrs, err := interfaceAddresses(interfaceName)
 	if err != nil {
@@ -186,7 +192,6 @@ func interfaceAddress(interfaceName string, v6 bool) (net.IP, error) {
 	return nil, errors.Wrapf(errNoSuitableAddress, "%s", interfaceName)
 }
 
-// interfaceAddresses returns all interface addresses.
 func interfaceAddresses(interfaceName string) ([]net.Addr, error) {
 	if interfaceName == "any" {
 		return net.InterfaceAddrs()

--- a/pkg/wanip/client.go
+++ b/pkg/wanip/client.go
@@ -14,7 +14,6 @@ import (
 
 // Client represents an active wanip object
 type Client struct {
-	ctx        context.Context
 	hc         *http.Client
 	ifname     string
 	userAgent  string
@@ -47,9 +46,7 @@ func WithMaxRetries(maxRetries int) Option {
 
 // New initializes a new wanip client
 func New(opts ...Option) *Client {
-	c := &Client{
-		ctx: context.Background(),
-	}
+	c := &Client{}
 	for _, opt := range opts {
 		opt(c)
 	}
@@ -99,7 +96,7 @@ func (c *Client) lookup(providers []provider, v6 bool) (net.IP, error) {
 }
 
 func (c *Client) getIP(httpc *http.Client, p provider) (net.IP, error) {
-	req, err := http.NewRequestWithContext(c.ctx, "GET", p.URL, nil)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", p.URL, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "request failed")
 	}

--- a/pkg/wanip/client.go
+++ b/pkg/wanip/client.go
@@ -14,7 +14,6 @@ import (
 
 // Client represents an active wanip object
 type Client struct {
-	hc         *http.Client
 	ifname     string
 	userAgent  string
 	maxRetries int
@@ -50,11 +49,6 @@ func New(opts ...Option) *Client {
 	for _, opt := range opts {
 		opt(c)
 	}
-
-	rc := retryablehttp.NewClient()
-	rc.RetryMax = c.maxRetries
-	rc.Logger = nil
-	c.hc = rc.StandardClient()
 	return c
 }
 
@@ -68,8 +62,8 @@ func (c *Client) IPv6() (net.IP, error) {
 	return c.lookup(defaultIPv6Providers, true)
 }
 
-func (c *Client) lookup(providers []provider, v6 bool) (net.IP, error) {
-	httpc, err := c.httpClient(v6)
+func (c *Client) lookup(providers []provider, wantIPv6 bool) (net.IP, error) {
+	httpc, err := c.httpClient(wantIPv6)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +78,7 @@ func (c *Client) lookup(providers []provider, v6 bool) (net.IP, error) {
 			})
 			continue
 		}
-		if ip != nil && ((v6 && ip.To16() != nil && ip.To4() == nil) || (!v6 && ip.To4() != nil)) {
+		if ip != nil && ((wantIPv6 && ip.To16() != nil && ip.To4() == nil) || (!wantIPv6 && ip.To4() != nil)) {
 			return ip, nil
 		}
 		failures = append(failures, ProviderFailure{
@@ -101,7 +95,7 @@ func (c *Client) getIP(httpc *http.Client, p provider) (net.IP, error) {
 		return nil, errors.Wrap(err, "request failed")
 	}
 	if c.userAgent != "" {
-		req.Header.Add("User-Agent", c.userAgent)
+		req.Header.Set("User-Agent", c.userAgent)
 	}
 
 	res, err := httpc.Do(req)
@@ -126,56 +120,57 @@ func (c *Client) getIP(httpc *http.Client, p provider) (net.IP, error) {
 	return ip, nil
 }
 
-func (c *Client) httpClient(v6 bool) (*http.Client, error) {
-	httpc := *c.hc
-	if t, err := c.transport(v6); err != nil {
+func (c *Client) httpClient(wantIPv6 bool) (*http.Client, error) {
+	rc := retryablehttp.NewClient()
+	rc.RetryMax = c.maxRetries
+	rc.Logger = nil
+	t, err := c.transport(rc.HTTPClient.Transport, wantIPv6)
+	if err != nil {
 		return nil, err
-	} else {
-		httpc.Transport = t
 	}
-	return &httpc, nil
+	rc.HTTPClient.Transport = t
+	return rc.StandardClient(), nil
 }
 
-func (c *Client) transport(v6 bool) (*http.Transport, error) {
+func (c *Client) transport(base http.RoundTripper, wantIPv6 bool) (*http.Transport, error) {
 	dialer := &net.Dialer{
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}
 
 	if c.ifname != "" {
-		ifadrr, err := interfaceAddress(c.ifname, v6)
+		ifadrr, err := interfaceAddress(c.ifname, wantIPv6)
 		if err != nil {
 			return nil, err
 		}
 		dialer.LocalAddr = &net.TCPAddr{IP: ifadrr}
 	}
 
-	// same as http.DefaultTransport but with a custom dialer with local addr
-	return &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: func(ctx context.Context, _, addr string) (net.Conn, error) {
-			network := "tcp4"
-			if v6 {
-				network = "tcp6"
-			}
-			return dialer.DialContext(ctx, network, addr)
-		},
-		ForceAttemptHTTP2:     true,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-	}, nil
+	network := "tcp4"
+	if wantIPv6 {
+		network = "tcp6"
+	}
+
+	baseTransport, ok := base.(*http.Transport)
+	if !ok || baseTransport == nil {
+		baseTransport = http.DefaultTransport.(*http.Transport)
+	}
+
+	t := baseTransport.Clone()
+	t.DialContext = func(ctx context.Context, _, addr string) (net.Conn, error) {
+		return dialer.DialContext(ctx, network, addr)
+	}
+	return t, nil
 }
 
-func interfaceAddress(interfaceName string, v6 bool) (net.IP, error) {
+func interfaceAddress(interfaceName string, wantIPv6 bool) (net.IP, error) {
 	addrs, err := interfaceAddresses(interfaceName)
 	if err != nil {
 		return nil, err
 	}
 	for _, addr := range addrs {
 		if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-			if v6 {
+			if wantIPv6 {
 				if ipnet.IP.To16() != nil && ipnet.IP.To4() == nil {
 					return ipnet.IP, nil
 				}

--- a/pkg/wanip/client.go
+++ b/pkg/wanip/client.go
@@ -169,16 +169,18 @@ func interfaceAddress(interfaceName string, wantIPv6 bool) (net.IP, error) {
 		return nil, err
 	}
 	for _, addr := range addrs {
-		if ipnet, ok := addr.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-			if wantIPv6 {
-				if ipnet.IP.To16() != nil && ipnet.IP.To4() == nil {
-					return ipnet.IP, nil
-				}
-			} else {
-				if ipnet.IP.To16() != nil && ipnet.IP.To4() != nil {
-					return ipnet.IP, nil
-				}
+		ipnet, ok := addr.(*net.IPNet)
+		if !ok || ipnet.IP.IsLoopback() {
+			continue
+		}
+		if wantIPv6 {
+			if ipnet.IP.To16() != nil && ipnet.IP.To4() == nil {
+				return ipnet.IP, nil
 			}
+			continue
+		}
+		if ipnet.IP.To4() != nil {
+			return ipnet.IP, nil
 		}
 	}
 	return nil, errors.Wrapf(errNoSuitableAddress, "%s", interfaceName)

--- a/pkg/wanip/client.go
+++ b/pkg/wanip/client.go
@@ -12,15 +12,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Errors holds slice of wanip errors
-type Errors []Error
-
-// Error holds wanip error
-type Error struct {
-	Err         error
-	ProviderURL string
-}
-
 // Client represents an active wanip object
 type Client struct {
 	ctx        context.Context
@@ -71,70 +62,46 @@ func New(opts ...Option) *Client {
 }
 
 // IPv4 returns your IPv4 address
-func (c *Client) IPv4() (net.IP, Errors) {
-	var errs Errors
-	for _, providerURL := range []string{
-		"https://ipv4.nsupdate.info/myip",
-		"https://v4.ident.me",
-		"https://ipv4.yunohost.org",
-		"https://ipv4.wtfismyip.com/text",
-	} {
-		ip, err := c.getIP(providerURL, false)
-		if err != nil {
-			errs = append(errs, Error{
-				Err:         err,
-				ProviderURL: providerURL,
-			})
-			continue
-		}
-		if ip != nil && len(ip.To4()) == net.IPv4len && strings.Contains(ip.String(), ".") {
-			return ip, nil
-		}
-		errs = append(errs, Error{
-			Err:         errors.Errorf("invalid IPv4 address: %s", ip.String()),
-			ProviderURL: providerURL,
-		})
-	}
-	return nil, errs
+func (c *Client) IPv4() (net.IP, error) {
+	return c.lookup(defaultIPv4Providers, false)
 }
 
 // IPv6 returns your IPv6 address
-func (c *Client) IPv6() (net.IP, Errors) {
-	var errs Errors
-	for _, providerURL := range []string{
-		"https://ipv6.nsupdate.info/myip",
-		"https://v6.ident.me",
-		"https://ipv6.yunohost.org",
-		"https://ipv6.wtfismyip.com/text",
-	} {
-		ip, err := c.getIP(providerURL, true)
+func (c *Client) IPv6() (net.IP, error) {
+	return c.lookup(defaultIPv6Providers, true)
+}
+
+func (c *Client) lookup(providers []provider, v6 bool) (net.IP, error) {
+	var failures []ProviderFailure
+	for _, p := range providers {
+		ip, err := c.getIP(p, v6)
 		if err != nil {
-			errs = append(errs, Error{
-				Err:         err,
-				ProviderURL: providerURL,
+			failures = append(failures, ProviderFailure{
+				URL: p.URL,
+				Err: err,
 			})
 			continue
 		}
-		if ip != nil && len(ip.To16()) == net.IPv6len && strings.Contains(ip.String(), ":") {
+		if ip != nil && ((v6 && ip.To16() != nil && ip.To4() == nil) || (!v6 && ip.To4() != nil)) {
 			return ip, nil
 		}
-		errs = append(errs, Error{
-			Err:         errors.Errorf("invalid IPv6 address: %s", ip.String()),
-			ProviderURL: providerURL,
+		failures = append(failures, ProviderFailure{
+			URL: p.URL,
+			Err: errors.Errorf("invalid IP address: %s", ip.String()),
 		})
 	}
-	return nil, errs
+	return nil, &ProviderError{Failures: failures}
 }
 
-func (c *Client) getIP(providerURL string, v6 bool) (net.IP, error) {
-	httpc := c.hc
+func (c *Client) getIP(p provider, v6 bool) (net.IP, error) {
+	httpc := *c.hc
 	if t, err := c.transport(v6); err != nil {
 		return nil, err
-	} else if t != nil {
+	} else {
 		httpc.Transport = t
 	}
 
-	req, err := http.NewRequestWithContext(c.ctx, "GET", providerURL, nil)
+	req, err := http.NewRequestWithContext(c.ctx, "GET", p.URL, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "request failed")
 	}
@@ -148,37 +115,47 @@ func (c *Client) getIP(providerURL string, v6 bool) (net.IP, error) {
 	}
 	defer res.Body.Close()
 
-	ip, err := io.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "request failed")
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, errors.Errorf("received invalid status code %d from %s: %s", res.StatusCode, providerURL, res.Body)
+		return nil, errors.Errorf("received invalid status code %d from %s: %s", res.StatusCode, p.URL, strings.TrimSpace(string(body)))
 	}
 
-	return net.ParseIP(string(ip)), nil
+	ip := p.Parse(body)
+	if ip == nil {
+		return nil, errors.Errorf("failed to parse IP address from %s", p.URL)
+	}
+	return ip, nil
 }
 
 // transport returns transport that uses the specified interface.
 func (c *Client) transport(v6 bool) (*http.Transport, error) {
-	if c.ifname == "" {
-		return nil, nil
+	dialer := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
 	}
 
-	ifadrr, err := interfaceAddress(c.ifname, v6)
-	if err != nil {
-		return nil, err
+	if c.ifname != "" {
+		ifadrr, err := interfaceAddress(c.ifname, v6)
+		if err != nil {
+			return nil, err
+		}
+		dialer.LocalAddr = &net.TCPAddr{IP: ifadrr}
 	}
 
 	// same as http.DefaultTransport but with a custom dialer with local addr
 	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-			LocalAddr: &net.TCPAddr{IP: ifadrr},
-		}).DialContext,
+		DialContext: func(ctx context.Context, _, addr string) (net.Conn, error) {
+			network := "tcp4"
+			if v6 {
+				network = "tcp6"
+			}
+			return dialer.DialContext(ctx, network, addr)
+		},
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
 		IdleConnTimeout:       90 * time.Second,
@@ -206,7 +183,7 @@ func interfaceAddress(interfaceName string, v6 bool) (net.IP, error) {
 			}
 		}
 	}
-	return nil, errors.Errorf("no suitable address found for interface: %s", interfaceName)
+	return nil, errors.Wrapf(errNoSuitableAddress, "%s", interfaceName)
 }
 
 // interfaceAddresses returns all interface addresses.

--- a/pkg/wanip/client_test.go
+++ b/pkg/wanip/client_test.go
@@ -20,49 +20,7 @@ var ua = fmt.Sprintf("ddns-route53/test go/%s %s", runtime.Version()[2:], runtim
 
 func TestWanIP(t *testing.T) {
 	c := New(WithMaxRetries(3), WithUserAgent(ua))
-
-	cases := []struct {
-		name string
-		v6   bool
-	}{
-		{
-			name: "v4",
-			v6:   false,
-		},
-		{
-			name: "v6",
-			v6:   true,
-		},
-	}
-	for _, tt := range cases {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.v6 {
-				ip, err := c.IPv6()
-				if ip == nil && err == nil {
-					t.Skip("Skipping unsupported IPv6 on host")
-				}
-				if err != nil && isNetworkUnreachable(err) {
-					t.Skip("Skipping unsupported IPv6 on host")
-				}
-				if ip == nil && err != nil {
-					t.Logf("IPv6 errors: %+v", providerFailures(err))
-				}
-				assert.NotEmpty(t, ip)
-				t.Logf("IPv6: %s", ip)
-			} else {
-				ip, err := c.IPv4()
-				if err != nil && isNetworkUnreachable(err) {
-					t.Skip("Skipping unsupported IPv4 on host")
-				}
-				if ip == nil && err != nil {
-					t.Logf("IPv4 errors: %+v", providerFailures(err))
-				}
-				assert.NotEmpty(t, ip)
-				t.Logf("IPv4: %s", ip)
-			}
-		})
-	}
+	testLiveLookup(t, c)
 }
 
 func TestCustomInterface(t *testing.T) {
@@ -70,49 +28,7 @@ func TestCustomInterface(t *testing.T) {
 	require.NoError(t, err)
 
 	c := New(WithInterfaceName(ifname), WithMaxRetries(3), WithUserAgent(ua))
-
-	cases := []struct {
-		name string
-		v6   bool
-	}{
-		{
-			name: "v4",
-			v6:   false,
-		},
-		{
-			name: "v6",
-			v6:   true,
-		},
-	}
-	for _, tt := range cases {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.v6 {
-				ip, err := c.IPv6()
-				if ip == nil && err == nil {
-					t.Skip("Skipping unsupported IPv6 on host")
-				}
-				if err != nil && isNetworkUnreachable(err) {
-					t.Skip("Skipping unsupported IPv6 on host")
-				}
-				if ip == nil && err != nil {
-					t.Logf("IPv6 errors: %+v", providerFailures(err))
-				}
-				assert.NotEmpty(t, ip)
-				t.Logf("IPv6: %s", ip)
-			} else {
-				ip, err := c.IPv4()
-				if err != nil && isNetworkUnreachable(err) {
-					t.Skip("Skipping unsupported IPv4 on host")
-				}
-				if ip == nil && err != nil {
-					t.Logf("IPv4 errors: %+v", providerFailures(err))
-				}
-				assert.NotEmpty(t, ip)
-				t.Logf("IPv4: %s", ip)
-			}
-		})
-	}
+	testLiveLookup(t, c)
 }
 
 func TestIPv6UnavailableReturnsProviderError(t *testing.T) {
@@ -207,6 +123,42 @@ func TestLookupRetriesProviderRequests(t *testing.T) {
 	require.NotNil(t, ip)
 	assert.Equal(t, "203.0.113.42", ip.String())
 	assert.EqualValues(t, 3, attempts.Load())
+}
+
+func testLiveLookup(t *testing.T, c *Client) {
+	t.Helper()
+
+	cases := []struct {
+		name   string
+		family string
+		lookup func() (net.IP, error)
+	}{
+		{
+			name:   "v4",
+			family: "IPv4",
+			lookup: c.IPv4,
+		},
+		{
+			name:   "v6",
+			family: "IPv6",
+			lookup: c.IPv6,
+		},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			ip, err := tt.lookup()
+			if err != nil && isNetworkUnreachable(err) {
+				t.Skipf("Skipping unsupported %s on host", tt.family)
+			}
+			if ip == nil && err != nil {
+				t.Logf("%s errors: %+v", tt.family, providerFailures(err))
+			}
+			assert.NotEmpty(t, ip)
+			t.Logf("%s: %s", tt.family, ip)
+		})
+	}
 }
 
 func defaultIfname() (string, error) {

--- a/pkg/wanip/client_test.go
+++ b/pkg/wanip/client_test.go
@@ -146,7 +146,6 @@ func testLiveLookup(t *testing.T, c *Client) {
 	}
 
 	for _, tt := range cases {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ip, err := tt.lookup()
 			if err != nil && isNetworkUnreachable(err) {
@@ -195,11 +194,27 @@ func providerFailures(err error) []ProviderFailure {
 
 func isNetworkUnreachable(err error) bool {
 	for _, failure := range providerFailures(err) {
-		if !isUnavailableError(failure.Err) &&
-			!strings.Contains(failure.Err.Error(), "forbidden by its access permissions") &&
-			!strings.Contains(failure.Err.Error(), "socket operation was attempted to an unreachable network") {
+		if !isUnavailableError(failure.Err) && !hasSandboxNetworkUnreachableMessage(failure.Err) {
 			return false
 		}
 	}
 	return true
+}
+
+var sandboxNetworkUnreachablePatterns = []string{
+	"forbidden by its access permissions",
+	"socket operation was attempted to an unreachable network",
+}
+
+func hasSandboxNetworkUnreachableMessage(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, pattern := range sandboxNetworkUnreachablePatterns {
+		if strings.Contains(msg, pattern) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/wanip/client_test.go
+++ b/pkg/wanip/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -183,6 +184,29 @@ func TestIPv4FallsBackToCloudflareTrace(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, ip)
 	assert.Equal(t, "203.0.113.42", ip.String())
+}
+
+func TestLookupRetriesProviderRequests(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) < 3 {
+			http.Error(w, "nope", http.StatusBadGateway)
+			return
+		}
+		_, _ = io.WriteString(w, "203.0.113.42")
+	}))
+	defer srv.Close()
+
+	c := New(WithMaxRetries(2))
+	ip, err := c.lookup([]provider{
+		{URL: srv.URL, Parse: parsePlainTextIP},
+	}, false)
+	require.NoError(t, err)
+	require.NotNil(t, ip)
+	assert.Equal(t, "203.0.113.42", ip.String())
+	assert.EqualValues(t, 3, attempts.Load())
 }
 
 func defaultIfname() (string, error) {

--- a/pkg/wanip/client_test.go
+++ b/pkg/wanip/client_test.go
@@ -1,13 +1,16 @@
 package wanip
 
 import (
-	"errors"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,19 +37,28 @@ func TestWanIP(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.v6 {
-				ip, errs := c.IPv6()
-				if errs != nil && isNetworkUnreachable(errs) {
+				ip, err := c.IPv6()
+				if ip == nil && err == nil {
 					t.Skip("Skipping unsupported IPv6 on host")
 				}
-				assert.NotEmpty(t, ip)
-				fmt.Println("IPv6:", ip)
-			} else {
-				ip, errs := c.IPv4()
-				if errs != nil && isNetworkUnreachable(errs) {
-					t.Skip("Skipping unsupported IPv4 on host")
+				if err != nil && isNetworkUnreachable(err) {
+					t.Skip("Skipping unsupported IPv6 on host")
+				}
+				if ip == nil && err != nil {
+					t.Logf("IPv6 errors: %+v", providerFailures(err))
 				}
 				assert.NotEmpty(t, ip)
-				fmt.Println("IPv4:", ip)
+				t.Logf("IPv6: %s", ip)
+			} else {
+				ip, err := c.IPv4()
+				if err != nil && isNetworkUnreachable(err) {
+					t.Skip("Skipping unsupported IPv4 on host")
+				}
+				if ip == nil && err != nil {
+					t.Logf("IPv4 errors: %+v", providerFailures(err))
+				}
+				assert.NotEmpty(t, ip)
+				t.Logf("IPv4: %s", ip)
 			}
 		})
 	}
@@ -75,34 +87,102 @@ func TestCustomInterface(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.v6 {
-				ip, errs := c.IPv6()
-				if errs != nil && isNetworkUnreachable(errs) {
+				ip, err := c.IPv6()
+				if ip == nil && err == nil {
 					t.Skip("Skipping unsupported IPv6 on host")
 				}
-				assert.NotEmpty(t, ip)
-				fmt.Println("IPv6:", ip)
-			} else {
-				ip, errs := c.IPv4()
-				if errs != nil && isNetworkUnreachable(errs) {
-					t.Skip("Skipping unsupported IPv4 on host")
+				if err != nil && isNetworkUnreachable(err) {
+					t.Skip("Skipping unsupported IPv6 on host")
+				}
+				if ip == nil && err != nil {
+					t.Logf("IPv6 errors: %+v", providerFailures(err))
 				}
 				assert.NotEmpty(t, ip)
-				fmt.Println("IPv4:", ip)
+				t.Logf("IPv6: %s", ip)
+			} else {
+				ip, err := c.IPv4()
+				if err != nil && isNetworkUnreachable(err) {
+					t.Skip("Skipping unsupported IPv4 on host")
+				}
+				if ip == nil && err != nil {
+					t.Logf("IPv4 errors: %+v", providerFailures(err))
+				}
+				assert.NotEmpty(t, ip)
+				t.Logf("IPv4: %s", ip)
 			}
 		})
 	}
 }
 
-func isNetworkUnreachable(errs Errors) bool {
-	for _, err := range errs {
-		if !strings.Contains(err.Err.Error(), "no such host") &&
-			!strings.Contains(err.Err.Error(), "network is unreachable") &&
-			!strings.Contains(err.Err.Error(), "cannot assign requested address") &&
-			!strings.Contains(err.Err.Error(), "no suitable address found for interface") {
-			return false
-		}
+func TestIPv6UnavailableReturnsProviderError(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+	ip, err := c.lookup([]provider{
+		{URL: "https://example.invalid", Parse: parsePlainTextIP},
+		{URL: "https://example.invalid", Parse: parseCloudflareTraceIP},
+	}, true)
+
+	assert.Nil(t, ip)
+	require.Error(t, err)
+
+	var providerErr *ProviderError
+	require.True(t, errors.As(err, &providerErr))
+	require.Len(t, providerErr.Failures, 2)
+	for _, failure := range providerErr.Failures {
+		assert.True(t, isUnavailableError(failure.Err))
 	}
-	return true
+}
+
+func TestParsePlainTextIP(t *testing.T) {
+	t.Parallel()
+
+	ip := parsePlainTextIP([]byte(" 203.0.113.10 \n"))
+	require.NotNil(t, ip)
+	assert.Equal(t, "203.0.113.10", ip.String())
+}
+
+func TestParseCloudflareTraceIP(t *testing.T) {
+	t.Parallel()
+
+	ip := parseCloudflareTraceIP([]byte("fl=29f5\nip=2001:db8::1\nts=1\n"))
+	require.NotNil(t, ip)
+	assert.Equal(t, "2001:db8::1", ip.String())
+}
+
+func TestIPv4FallsBackToCloudflareTrace(t *testing.T) {
+	t.Parallel()
+
+	awsGlobal := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusBadGateway)
+	}))
+	defer awsGlobal.Close()
+
+	awsLegacy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "still not an ip")
+	}))
+	defer awsLegacy.Close()
+
+	cloudflare := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "fl=29f5\nip=203.0.113.42\nts=1\n")
+	}))
+	defer cloudflare.Close()
+
+	nsupdate := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Fatal("nsupdate fallback should not be used after cloudflare succeeds")
+	}))
+	defer nsupdate.Close()
+
+	c := New()
+	ip, err := c.lookup([]provider{
+		{URL: awsGlobal.URL, Parse: parsePlainTextIP},
+		{URL: awsLegacy.URL, Parse: parsePlainTextIP},
+		{URL: cloudflare.URL, Parse: parseCloudflareTraceIP},
+		{URL: nsupdate.URL, Parse: parsePlainTextIP},
+	}, false)
+	require.NoError(t, err)
+	require.NotNil(t, ip)
+	assert.Equal(t, "203.0.113.42", ip.String())
 }
 
 func defaultIfname() (string, error) {
@@ -124,4 +204,26 @@ func defaultIfname() (string, error) {
 		}
 	}
 	return "", errors.New("no default interface found")
+}
+
+func providerFailures(err error) []ProviderFailure {
+	if err == nil {
+		return nil
+	}
+	var providerErr *ProviderError
+	if errors.As(err, &providerErr) {
+		return providerErr.Failures
+	}
+	return []ProviderFailure{{Err: err}}
+}
+
+func isNetworkUnreachable(err error) bool {
+	for _, failure := range providerFailures(err) {
+		if !isUnavailableError(failure.Err) &&
+			!strings.Contains(failure.Err.Error(), "forbidden by its access permissions") &&
+			!strings.Contains(failure.Err.Error(), "socket operation was attempted to an unreachable network") {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/wanip/neterr.go
+++ b/pkg/wanip/neterr.go
@@ -1,0 +1,20 @@
+package wanip
+
+import (
+	"net"
+
+	"github.com/pkg/errors"
+)
+
+var errNoSuitableAddress = errors.New("no suitable address found for interface")
+
+func isUnavailableError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, errNoSuitableAddress) || isUnavailableErrno(err) {
+		return true
+	}
+	var dnsErr *net.DNSError
+	return errors.As(err, &dnsErr) && isUnavailableDNSError(dnsErr)
+}

--- a/pkg/wanip/neterr_test.go
+++ b/pkg/wanip/neterr_test.go
@@ -1,0 +1,17 @@
+package wanip
+
+import (
+	"net"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsUnavailableError(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isUnavailableError(errNoSuitableAddress))
+	assert.True(t, isUnavailableError(errors.Wrap(&net.DNSError{IsNotFound: true}, "wrapped")))
+	assert.False(t, isUnavailableError(errors.New("nope")))
+}

--- a/pkg/wanip/neterr_unix.go
+++ b/pkg/wanip/neterr_unix.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package wanip
+
+import (
+	"net"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+func isUnavailableErrno(err error) bool {
+	return errors.Is(err, syscall.ENETUNREACH) ||
+		errors.Is(err, syscall.EHOSTUNREACH) ||
+		errors.Is(err, syscall.EADDRNOTAVAIL) ||
+		errors.Is(err, syscall.EAFNOSUPPORT)
+}
+
+func isUnavailableDNSError(err *net.DNSError) bool {
+	return err != nil && err.IsNotFound
+}

--- a/pkg/wanip/neterr_unix_test.go
+++ b/pkg/wanip/neterr_unix_test.go
@@ -1,0 +1,28 @@
+//go:build !windows
+
+package wanip
+
+import (
+	"net"
+	"syscall"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsUnavailableErrno(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isUnavailableErrno(errors.Wrap(syscall.ENETUNREACH, "wrapped")))
+	assert.True(t, isUnavailableErrno(errors.Wrap(syscall.EADDRNOTAVAIL, "wrapped")))
+	assert.False(t, isUnavailableErrno(errors.Wrap(syscall.EINVAL, "wrapped")))
+}
+
+func TestIsUnavailableDNSError(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isUnavailableDNSError(&net.DNSError{IsNotFound: true}))
+	assert.False(t, isUnavailableDNSError(&net.DNSError{IsNotFound: false}))
+	assert.False(t, isUnavailableDNSError(nil))
+}

--- a/pkg/wanip/neterr_windows.go
+++ b/pkg/wanip/neterr_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package wanip
+
+import (
+	"net"
+	"strings"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
+)
+
+func isUnavailableErrno(err error) bool {
+	return errors.Is(err, windows.WSAENETUNREACH) ||
+		errors.Is(err, windows.WSAEHOSTUNREACH) ||
+		errors.Is(err, windows.WSAEADDRNOTAVAIL) ||
+		errors.Is(err, windows.WSAEAFNOSUPPORT) ||
+		errors.Is(err, windows.WSAHOST_NOT_FOUND) ||
+		errors.Is(err, windows.WSANO_DATA)
+}
+
+func isUnavailableDNSError(err *net.DNSError) bool {
+	if err == nil {
+		return false
+	}
+	if err.IsNotFound {
+		return true
+	}
+	return strings.HasSuffix(err.Err, windows.WSAHOST_NOT_FOUND.Error()) ||
+		strings.HasSuffix(err.Err, windows.WSANO_DATA.Error())
+}

--- a/pkg/wanip/neterr_windows_test.go
+++ b/pkg/wanip/neterr_windows_test.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package wanip
+
+import (
+	"net"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/windows"
+)
+
+func TestIsUnavailableErrno(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isUnavailableErrno(errors.Wrap(windows.WSAENETUNREACH, "wrapped")))
+	assert.True(t, isUnavailableErrno(errors.Wrap(windows.WSAEADDRNOTAVAIL, "wrapped")))
+	assert.False(t, isUnavailableErrno(errors.Wrap(windows.WSAEINVAL, "wrapped")))
+}
+
+func TestIsUnavailableDNSError(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isUnavailableDNSError(&net.DNSError{IsNotFound: true}))
+	assert.True(t, isUnavailableDNSError(&net.DNSError{Err: "getaddrinfow: " + windows.WSANO_DATA.Error()}))
+	assert.True(t, isUnavailableDNSError(&net.DNSError{Err: "lookup foo: " + windows.WSAHOST_NOT_FOUND.Error()}))
+	assert.False(t, isUnavailableDNSError(&net.DNSError{Err: "some other dns failure"}))
+	assert.False(t, isUnavailableDNSError(nil))
+}

--- a/pkg/wanip/provider.go
+++ b/pkg/wanip/provider.go
@@ -1,0 +1,64 @@
+package wanip
+
+import (
+	"net"
+	"strings"
+)
+
+type ProviderFailure struct {
+	URL string
+	Err error
+}
+
+type ProviderError struct {
+	Failures []ProviderFailure
+}
+
+func (e *ProviderError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return "all WAN IP providers failed"
+}
+
+func (e *ProviderError) Unwrap() []error {
+	if e == nil {
+		return nil
+	}
+	errs := make([]error, 0, len(e.Failures))
+	for _, failure := range e.Failures {
+		errs = append(errs, failure.Err)
+	}
+	return errs
+}
+
+type provider struct {
+	URL   string
+	Parse func([]byte) net.IP
+}
+
+var defaultIPv4Providers = []provider{
+	{URL: "https://checkip.global.api.aws", Parse: parsePlainTextIP},
+	{URL: "https://checkip.amazonaws.com", Parse: parsePlainTextIP},
+	{URL: "https://cloudflare.com/cdn-cgi/trace", Parse: parseCloudflareTraceIP},
+	{URL: "https://ipv4.nsupdate.info/myip", Parse: parsePlainTextIP},
+}
+
+var defaultIPv6Providers = []provider{
+	{URL: "https://checkip.global.api.aws", Parse: parsePlainTextIP},
+	{URL: "https://cloudflare.com/cdn-cgi/trace", Parse: parseCloudflareTraceIP},
+	{URL: "https://ipv6.nsupdate.info/myip", Parse: parsePlainTextIP},
+}
+
+func parsePlainTextIP(body []byte) net.IP {
+	return net.ParseIP(strings.TrimSpace(string(body)))
+}
+
+func parseCloudflareTraceIP(body []byte) net.IP {
+	for _, line := range strings.Split(string(body), "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), "ip="); ok {
+			return net.ParseIP(strings.TrimSpace(rest))
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This change replaces the old WAN IP lookup flow with a cleaner provider stack built around well-known endpoints from AWS, Cloudflare, and nsupdate, and it tightens the client and test code around that new lookup model.

The `wanip` package now uses explicit provider definitions and parser functions for plain text and Cloudflare trace responses, returns a single `ProviderError` with per-provider failures instead of a custom error slice API, and classifies interface and network availability through dedicated neterr helpers. The HTTP client path was also cleaned up so each lookup builds a retryable client from a cloned default transport, preserves retry behavior while customizing dialing, reuses the client across provider fallbacks, and simplifies the internal IPv4 and IPv6 selection logic.

The old provider list depended on endpoints that were a bit opaque and not especially common or well-known, which made the public IP detection path harder to trust and reason about. This refactor moves the package to more recognizable providers, makes the error surface more idiomatic, and fixes the transport customization so the configured retry behavior actually remains in effect instead of being quietly sidestepped.